### PR TITLE
CI: add changelog check for pull requests

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,17 @@
+name: CHANGELOG related checks per pull requests
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check-changelog:
+    name: Check changelog action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v3
+        with:
+          changelog: CHANGELOG.md


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that requires a CHANGELOG.md entry on every pull request
- Uses [tarides/changelog-check-action@v3](https://github.com/tarides/changelog-check-action) to verify changelog is updated
- Triggers on PR open, sync, reopen, and label changes against `main`

## Test plan

- Open a PR without a changelog entry and verify the check fails
- Open a PR with a changelog entry and verify the check passes